### PR TITLE
Fix changes according to new espressif api

### DIFF
--- a/BNO055ESP32.cpp
+++ b/BNO055ESP32.cpp
@@ -27,6 +27,7 @@
 
 /*!please use the following clang-settings {BasedOnStyle: Google, ColumnLimit: 130, IndentWidth: 4}!*/
 #include "BNO055ESP32.h"
+#include "rom/gpio.h"
 
 /* used in ESP_LOG macros */
 static const char *BNO055_LOG_TAG = "BNO055";
@@ -170,7 +171,7 @@ void BNO055::uart_readLen(bno055_reg_t reg, uint8_t *buffer, uint8_t len, uint32
                 data = (uint8_t *)malloc(len + 2);
                 if (data == NULL) throw std::bad_alloc();  // malloc failed
             }
-            rxBytes = uart_read_bytes(_uartPort, data, (len + 2), timeoutMS / portTICK_RATE_MS);
+            rxBytes = uart_read_bytes(_uartPort, data, (len + 2), timeoutMS / portTICK_PERIOD_MS);
             if (rxBytes > 0) {
 #ifndef BNO055_DEBUG_OFF
                 ESP_LOGD(BNO055_LOG_TAG, "(RL) Read %d bytes", rxBytes);
@@ -231,7 +232,7 @@ void BNO055::uart_writeLen(bno055_reg_t reg, uint8_t *data2write, uint8_t len, u
 #endif
 
         if (timeoutMS > 0) {  // check response (if expected)
-            rxBytes = uart_read_bytes(_uartPort, data, 2, timeoutMS / portTICK_RATE_MS);
+            rxBytes = uart_read_bytes(_uartPort, data, 2, timeoutMS / portTICK_PERIOD_MS);
             if (rxBytes > 0) {
 #ifndef BNO055_DEBUG_OFF
                 ESP_LOGD(BNO055_LOG_TAG, "(WL) Read %d bytes", rxBytes);  // DEBUG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,1 @@
-idf_component_register(SRCS "BNO055ESP32.cpp" INCLUDE_DIRS "include")
+idf_component_register(SRCS "BNO055ESP32.cpp" INCLUDE_DIRS "include" REQUIRES "driver")

--- a/include/BNO055ESP32.h
+++ b/include/BNO055ESP32.h
@@ -663,7 +663,7 @@ class BNO055 {
                                        .stop_bits = UART_STOP_BITS_1,
                                        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
                                        .rx_flow_ctrl_thresh = 0,
-                                       .use_ref_tick = false};
+                                       .source_clk = uart_sclk_t::UART_SCLK_APB};
 
     typedef enum {
         BNO055_VECTOR_ACCELEROMETER = 0x08,  // Default: m/s²


### PR DESCRIPTION
According to the API change in the new espressif, I created changes that fix compilation errors.
I haven't tested this on physical hardware yet, and I don't think it should be merged.
I'm creating this PR because maybe it will solve someone's compilation problem.

1. `fatal error: driver/i2c.h: No such file or directory` [Solution](https://github.com/espressif/esp-idf/issues/8799).
![image](https://github.com/ShellAddicted/BNO055ESP32/assets/108528301/1a771549-626f-42c9-bc7b-3313502bd109)

2. `error: 'const uart_config_t' has no non-static data member named 'use_ref_tick'` [Solution](https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32/api-reference/peripherals/uart.html#_CPPv4N13uart_config_t10source_clkE).
![image](https://github.com/ShellAddicted/BNO055ESP32/assets/108528301/0e2e1610-8f99-463b-b320-3c82aad2baa3)

3. `error: 'gpio_pad_select_gpio' was not declared in this scope; did you mean 'esp_rom_gpio_pad_select_gpio'?
` [Solution](https://github.com/espressif/ESP8266_RTOS_SDK/pull/477).
![image](https://github.com/ShellAddicted/BNO055ESP32/assets/108528301/ed9ca4ad-c663-4d5c-bf24-b084261ac433)

4. ` error: 'portTICK_RATE_MS' was not declared in this scope;` [Solution](https://github.com/espressif/esp-idf/issues/51).
![image](https://github.com/ShellAddicted/BNO055ESP32/assets/108528301/af46e4e4-b517-48e2-9c8d-27bac47014c9)




